### PR TITLE
TypicalForwardVoltage.cs - updated ResistorLimited from 0 to 3.3F

### DIFF
--- a/Source/Netduino.Foundation/LEDs/TypicalForwardVoltage.cs
+++ b/Source/Netduino.Foundation/LEDs/TypicalForwardVoltage.cs
@@ -11,6 +11,6 @@ namespace Netduino.Foundation.LEDs
         public const float Yellow = 3.5F;
         public const float White = 2.15F;
 
-        public const float ResistorLimited = 0.0F;
+        public const float ResistorLimited = 3.3F;
     }
 }


### PR DESCRIPTION
This shoud correct RgbPwmLed.cs when using the default forward voltage values.