### PR TITLE
[RgbPwmLed] Loop bug fix

### DIFF
--- a/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
+++ b/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
@@ -131,6 +131,8 @@ namespace Netduino.Foundation.LEDs
 
             // stop any existing animations
             this.Stop();
+
+            _running = true;
             this._animationThread = new Thread(() => 
             {
                 while (_running)


### PR DESCRIPTION
Added _running = true; to enter loop so it can do Running Colors animation (and other effects)