### PR TITLE
Changes to animation thread to prevent a thread leak and properly stop animation

### DIFF
--- a/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
+++ b/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
@@ -33,7 +33,6 @@ namespace Netduino.Foundation.LEDs
         public float BlueForwardVoltage { get; protected set; }
 
         protected Thread _animationThread = null;
-        protected bool _running = false;
 
         /// <summary>
         /// The Color the LED has been set to.
@@ -130,12 +129,11 @@ namespace Netduino.Foundation.LEDs
             }
 
             // stop any existing animations
-            this.Stop();
+            this._animationThread?.Abort();
 
-            _running = true;
             this._animationThread = new Thread(() => 
             {
-                while (_running)
+                while (true)
                 {
                     for (int i = 0; i < colors.Count; i++)
                     {
@@ -147,9 +145,6 @@ namespace Netduino.Foundation.LEDs
                     if (!loop)
                         Stop();
                 }
-
-                // When stopped we turn off the LED
-                SetColor(Color.FromHsba(this.Color.Hue, this.Color.Saturation, 0.0));
             });
             this._animationThread.Start();
         }
@@ -238,8 +233,8 @@ namespace Netduino.Foundation.LEDs
         /// </summary>
         public void Stop()
         {
-            _running = false;
-            //SetColor(Color.FromHsba(this.Color.Hue, this.Color.Saturation, 0.0));
+            _animationThread?.Abort();
+            SetColor(Color.FromHsba(this.Color.Hue, this.Color.Saturation, 0.0));
         }
     }
 }


### PR DESCRIPTION
In StartRunningColors() it is possible for there to be a thread leak if it is called multiple times without calling Stop() outside the method (and also waiting at least the animation duration). Stop() would just set _running to false and immediately after it back to true so a currently running animation thread most often wouldn't be at the end of it's while loop at this time, so another thread will kick off and the current one will continue. This causes odd animation behavior and eventually crashes the Netduino. Because of a related race condition, if an animation is stopped and a color is set right after, the color that is set will most often get overridden by the animation thread turning off the LED when it completes.