### PR TITLE
[RgbPwmLed] Added overloaded constructors and methods to easily turn on/off the LED

### DIFF
--- a/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
+++ b/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
@@ -52,7 +52,19 @@ namespace Netduino.Foundation.LEDs
         {
             get { return _color; }
         } protected Color _color = new Color(0, 0, 0);
-        
+
+        public RgbPwmLed(H.Cpu.PWMChannel redPin, H.Cpu.PWMChannel greenPin, H.Cpu.PWMChannel bluePin)
+           : this(redPin, greenPin, bluePin, TypicalForwardVoltage.ResistorLimited, TypicalForwardVoltage.ResistorLimited,
+                 TypicalForwardVoltage.ResistorLimited, true)
+        {
+        }
+
+        public RgbPwmLed(H.Cpu.PWMChannel redPin, H.Cpu.PWMChannel greenPin, H.Cpu.PWMChannel bluePin, bool isCommonCathode)
+            : this(redPin, greenPin, bluePin, TypicalForwardVoltage.ResistorLimited, TypicalForwardVoltage.ResistorLimited,
+                  TypicalForwardVoltage.ResistorLimited, isCommonCathode)
+        {
+        }
+
         /// <summary>
         /// 
         /// Implementation notes: Architecturally, it would be much cleaner to construct this class
@@ -91,9 +103,9 @@ namespace Netduino.Foundation.LEDs
             GreenPin = greenPin;
             BluePin = bluePin;
 
-            RedPwm = new H.PWM(RedPin, 100, 0, false);
-            GreenPwm = new H.PWM(GreenPin, 100, 0, false);
-            BluePwm = new H.PWM(BluePin, 100, 0, false);
+            RedPwm = new H.PWM(RedPin, 100, 0, !isCommonCathode);
+            GreenPwm = new H.PWM(GreenPin, 100, 0, !isCommonCathode);
+            BluePwm = new H.PWM(BluePin, 100, 0, !isCommonCathode);
         }
 
         /// <summary>
@@ -124,17 +136,8 @@ namespace Netduino.Foundation.LEDs
             GreenPwm.DutyCycle = (_color.G * _maximumGreenPwmDuty);
             BluePwm.DutyCycle = (_color.B * _maximumBluePwmDuty);
 
-            if(IsCommonCathode == false)
-            {
-                RedPwm.DutyCycle = 1 - RedPwm.DutyCycle;
-                GreenPwm.DutyCycle = 1 - GreenPwm.DutyCycle;
-                BluePwm.DutyCycle = 1 - BluePwm.DutyCycle;
-            }
-
             // start our PWMs.
-            RedPwm.Start();
-            GreenPwm.Start();
-            BluePwm.Start();
+            TurnOn();
         }
 
         // HACK/TODO: this is the signature I want, but it's broken until 4.4. (https://github.com/NETMF/netmf-interpreter/issues/87)
@@ -340,6 +343,26 @@ namespace Netduino.Foundation.LEDs
         public void Stop()
         {
             _isRunning = false;
+        }
+
+        /// <summary>
+        /// Turns off the LED
+        /// </summary>
+        public void TurnOff()
+        {
+            RedPwm.Stop();
+            GreenPwm.Stop();
+            BluePwm.Stop();
+        }
+
+        /// <summary>
+        /// Turns on the LED
+        /// </summary>
+        public void TurnOn()
+        {
+            RedPwm.Start();
+            GreenPwm.Start();
+            BluePwm.Start();
         }
     }
 }

--- a/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
+++ b/Source/Netduino.Foundation/LEDs/RgbPwmLed.cs
@@ -53,18 +53,6 @@ namespace Netduino.Foundation.LEDs
             get { return _color; }
         } protected Color _color = new Color(0, 0, 0);
 
-        public RgbPwmLed(H.Cpu.PWMChannel redPin, H.Cpu.PWMChannel greenPin, H.Cpu.PWMChannel bluePin)
-           : this(redPin, greenPin, bluePin, TypicalForwardVoltage.ResistorLimited, TypicalForwardVoltage.ResistorLimited,
-                 TypicalForwardVoltage.ResistorLimited, true)
-        {
-        }
-
-        public RgbPwmLed(H.Cpu.PWMChannel redPin, H.Cpu.PWMChannel greenPin, H.Cpu.PWMChannel bluePin, bool isCommonCathode)
-            : this(redPin, greenPin, bluePin, TypicalForwardVoltage.ResistorLimited, TypicalForwardVoltage.ResistorLimited,
-                  TypicalForwardVoltage.ResistorLimited, isCommonCathode)
-        {
-        }
-
         /// <summary>
         /// 
         /// Implementation notes: Architecturally, it would be much cleaner to construct this class


### PR DESCRIPTION
Some overloaded constructors were added for ease of creation and some methods to power on/off the LED easily. I noticed even with a duty cycle of 0 I was still getting some faint light from the red LED, so I thought a method to turn it off would be nice instead of having to stop each PWM pin.

Also, the PWMs can be created inverted (common vs anode) and removes the need to do math based on common/anode in UpdateColor().